### PR TITLE
💄 Add custom theme

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,9 @@
+import type { Theme } from "vitepress";
+
+import DefaultTheme from "vitepress/theme";
+
+import "./style.css";
+
+export default <Theme>{
+    ...DefaultTheme,
+};

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,29 @@
+:root {
+    --vp-c-brand-1: #e8d400;
+    --vp-c-brand-2: #e27c08;
+    --vp-c-brand-3: var(--vp-c-brand-2);
+}
+
+/* Dark mode specific configurations */
+/* .dark {
+	...
+} */
+
+/* Enables footer on all pages instead of only the home page */
+footer.VPFooter {
+    display: block !important;
+    z-index: 100 !important;
+}
+
+@media all and (max-width: 450px) {
+    /* Hides the logo text on mobile phones */
+    .VPNav div.logo a {
+        width: 23px;
+        overflow: hidden;
+    }
+    /* Fixes compression of logo on phone screens */
+    .VPNav div.logo a img {
+        object-fit: cover;
+        object-position: left;
+    }
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2,6 +2,13 @@
     --vp-c-brand-1: #e8d400;
     --vp-c-brand-2: #e27c08;
     --vp-c-brand-3: var(--vp-c-brand-2);
+
+    --vp-home-hero-image-background-image: linear-gradient(
+        -30deg,
+        var(--vp-c-brand-2) 40%,
+        var(--vp-c-brand-1) 50%
+    );
+    --vp-home-hero-image-filter: blur(100px);
 }
 
 /* Dark mode specific configurations */


### PR DESCRIPTION
This pull request sets up a custom theme for the VitePress documentation site and introduces brand-specific styling and mobile optimizations. The main changes are the creation of a theme entry point and the addition of a custom CSS file to control appearance and layout.

Theme setup:

* Added a new theme entry point in `docs/.vitepress/theme/index.ts` that imports the default VitePress theme and applies custom styles from `style.css`.

Branding and styling:

* Defined brand colors and custom CSS variables in `docs/.vitepress/theme/style.css` for consistent site branding.
* Ensured the site footer is always visible by overriding its display property in the custom CSS.

Mobile responsiveness:

* Improved mobile layout by hiding logo text and adjusting logo image styling for screens under 450px wide.