### PR TITLE
👷 Deploy with actions to Cloudflare pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,18 +40,16 @@ jobs:
                   cache: npm
                   cache-dependency-path: docs/package-lock.json
 
-            - name: Setup Pages
-              uses: actions/configure-pages@v4
-
             - name: Install dependencies
               run: npm ci
 
             - name: Build with VitePress
               run: npm run build -- --base "/${{ github.event.repository.name }}/"
 
-            - name: Upload artifact
-              uses: actions/upload-pages-artifact@v3
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v4
               with:
+                  name: docs-dist
                   path: docs/.vitepress/dist
 
     deploy:
@@ -59,11 +57,21 @@ jobs:
         runs-on: ubuntu-latest
         needs: build
 
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
+        permissions:
+            contents: read
+            deployments: write
 
         steps:
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@v4
+            - name: Download build artifacts
+              uses: actions/download-artifact@v5
+              with:
+                  name: docs-dist
+                  path: dist
+
+            - name: Deploy to Cloudflare Pages
+              uses: cloudflare/wrangler-action@v3
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+                  command: pages deploy dist --project-name=rubberduckcrew


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to use Cloudflare Pages instead of GitHub Pages. The build and deployment steps have been restructured to support the new platform and artifact handling.

**Deployment platform migration:**

* Replaced the GitHub Pages deployment step with a Cloudflare Pages deployment using `cloudflare/wrangler-action@v3`, including necessary authentication via Cloudflare API and account secrets.

**Artifact handling updates:**

* Switched from uploading pages artifacts with `actions/upload-pages-artifact@v3` to using `actions/upload-artifact@v4` for build output, and added a corresponding download step in the deploy job with `actions/download-artifact@v5`.

**Workflow permissions and environment:**

* Updated deployment job permissions to explicitly grant `contents: read` and `deployments: write`, and removed the previous `environment` configuration for GitHub Pages.