### PR TITLE
👷 Fix base path for Cloudflare deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
               run: npm ci
 
             - name: Build with VitePress
-              run: npm run build -- --base "/${{ github.event.repository.name }}/"
+              run: npm run build
 
             - name: Upload build artifacts
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the documentation build workflow to simplify the VitePress build command.

Documentation build process:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL47-R47): Removed the custom `--base` argument from the VitePress build step, so the build now uses the default base path.