### PR TITLE
👷 Output deploy urls

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,8 +51,9 @@ jobs:
 
     deploy:
         name: Deploy docs
-        runs-on: ubuntu-latest
         needs: build
+        if: ${{ ( github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') ) && !github.event.pull_request.head.repo.fork}}
+        runs-on: ubuntu-latest
 
         permissions:
             contents: read
@@ -75,13 +76,21 @@ jobs:
                   gitHubToken: ${{ secrets.GITHUB_TOKEN }}
                   command: pages deploy dist --project-name=rubberduckcrew --branch=${{ github.head_ref || github.ref_name }}
 
-            - uses: thollander/actions-comment-pull-request@v3
+            - name: Comment deployment info
+              uses: thollander/actions-comment-pull-request@v3
               if: github.event_name == 'pull_request'
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   comment-tag: deployment-info
                   mode: recreate
                   message: |
-                      **🌐 Preview Deployments:**
+                      **🌐 Preview Deployments**
                       - Commit: ${{ steps.deploy.outputs.deployment-url }}
                       - Branch: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+
+            - name: Remove build request label
+              uses: IamPekka058/removeLabels@v2
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  labels: |
+                      - ⚗️ Request Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,10 @@ name: Build and deploy docs
 on:
     push:
         branches: [main]
+        paths: [docs/**, .github/workflows/docs.yml]
     pull_request:
-        types: [opened, synchronize]
+        types: [opened, labeled, synchronize]
+        paths: [docs/**, .github/workflows/docs.yml]
 
 permissions:
     contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
         permissions:
             contents: read
             deployments: write
+            pull-requests: write
 
         steps:
             - name: Download build artifacts
@@ -81,6 +82,6 @@ jobs:
                   comment-tag: deployment-info
                   mode: recreate
                   message: |
-                      **Deployment URLs:**
+                      **🌐 Preview Deployments:**
                       - Commit: ${{ steps.deploy.outputs.deployment-url }}
                       - Branch: ${{ steps.deploy.outputs.pages-deployment-alias-url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,8 +67,17 @@ jobs:
 
             - name: Deploy to Cloudflare Pages
               uses: cloudflare/wrangler-action@v3
+              id: deploy
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   gitHubToken: ${{ secrets.GITHUB_TOKEN }}
                   command: pages deploy dist --project-name=rubberduckcrew --branch=${{ github.head_ref || github.ref_name }}
+
+            - name: Output deployment URL
+              env:
+                  DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+                  DEPLOYMENT_ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+              run: |
+                  echo "Deployment URL: $DEPLOYMENT_URL"
+                  echo "Deployment Alias URL: $DEPLOYMENT_ALIAS_URL"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,10 +74,13 @@ jobs:
                   gitHubToken: ${{ secrets.GITHUB_TOKEN }}
                   command: pages deploy dist --project-name=rubberduckcrew --branch=${{ github.head_ref || github.ref_name }}
 
-            - name: Output deployment URL
-              env:
-                  DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
-                  DEPLOYMENT_ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-              run: |
-                  echo "Deployment URL: $DEPLOYMENT_URL"
-                  echo "Deployment Alias URL: $DEPLOYMENT_ALIAS_URL"
+            - uses: thollander/actions-comment-pull-request@v3
+              if: github.event_name == 'pull_request'
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  comment-tag: deployment-info
+                  mode: recreate
+                  message: |
+                      **Deployment URLs:**
+                      - Commit: ${{ steps.deploy.outputs.deployment-url }}
+                      - Branch: ${{ steps.deploy.outputs.pages-deployment-alias-url }}


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to improve preview deployments for pull requests and streamline build request handling. The changes ensure that documentation builds and deployments are triggered only when relevant files change, add support for a build request label, and enhance pull request feedback with deployment info and automated label removal.

**Workflow triggers and conditions:**

* The workflow now only triggers on changes to files in the `docs/` directory or the workflow file itself, and supports the `labeled` event for pull requests.
* The deploy job runs only for the `main` branch or when the pull request is labeled with `⚗️ Request Build`, and is skipped for forks.

**Deployment and feedback enhancements:**

* The deploy step uses an explicit `id` for output reference, and after deployment, a comment is added to the pull request with preview deployment URLs.
* The workflow now requests `pull-requests: write` permission to enable commenting on pull requests.
* After deployment, the `⚗️ Request Build` label is automatically removed from the pull request.