### PR TITLE
🚑 Fix removing labels in main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,6 +92,7 @@ jobs:
 
             - name: Remove build request label
               uses: IamPekka058/removeLabels@v2
+              if: github.event_name == 'pull_request'
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   labels: |


### PR DESCRIPTION
This pull request introduces a small change to the documentation workflow configuration. The change adds a conditional to the step that removes the build request label, ensuring it only runs for pull request events.