### PR TITLE
🔧 Add renovate base config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>rubberduckcrew/.github//configs/renovate/renovate-rubberduckcrew.json"
+    ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "github>rubberduckcrew/.github//configs/renovate/renovate-rubberduckcrew.json"
+        "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json"
     ]
 }

--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "major": {
+        "automerge": false
+    },
+    "labels": ["📌 Dependencies"],
+    "commitMessagePrefix": "⬆️",
+    "commitMessageAction": "Upgrade",
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["pin"],
+            "commitMessagePrefix": "📌",
+            "commitMessageAction": "Pin"
+        },
+        {
+            "matchUpdateTypes": ["rollback"],
+            "commitMessagePrefix": "⬇️",
+            "commitMessageAction": "Downgrade"
+        }
+    ],
+    "dependencyDashboardTitle": "📌 Dependency Dashboard",
+    "dependencyDashboardLabels": ["📌 Dependencies"]
+}


### PR DESCRIPTION
This pull request introduces Renovate configuration files to enable automated dependency management for the repository. The main changes are the addition of a repository-specific configuration file and a shared configuration file for the organization.

Renovate setup:

* Added `.github/renovate.json` to configure Renovate for the repository, extending the shared organization configuration.
* Added `configs/renovate/renovate-rubberduckcrew.json` with recommended settings, custom commit message conventions, dependency labeling, and dashboard configuration for the organization.