### PR TITLE
💚 Fix sync labels config url

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,6 +3,9 @@ name: Sync labels
 on:
     schedule:
         - cron: "0 3 * * 0"
+    push:
+        branches: [main]
+        paths: [.github/workflows/sync-labels.yml]
     workflow_dispatch:
 
 jobs:
@@ -18,4 +21,4 @@ jobs:
               uses: srealmoreno/label-sync-action@v2.0.0
               with:
                   clean-labels: true
-                  config-file: https://raw.githubusercontent.com/RubberDuckCrew/gitdone/refs/heads/main/configs/conventions/labels.yml
+                  config-file: https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/labels.yml


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for syncing labels to improve configuration management and ensure the workflow runs automatically when relevant changes are made. The most important changes are:

**Workflow triggers:**

* Added a `push` trigger so the sync-labels workflow runs automatically when changes are pushed to the `main` branch and specifically to the `.github/workflows/sync-labels.yml` file.

**Configuration management:**

* Updated the `config-file` URL to use the shared `.github` repository for label conventions, improving maintainability and consistency across repositories.