### PR TITLE
👷 Fix enforce branch names input

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -32,5 +32,5 @@ jobs:
             - name: Enforce pull request branch names
               uses: IamPekka058/branchMatchRegex@v1
               with:
-                  inputPath: https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/branches.yml
+                  path: https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/branches.yml
                   useWildcard: true


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration for enforcing pull request branch names. The change updates the input parameter name to match the expected format for the action.

* Changed the parameter from `inputPath` to `path` in the branch name enforcement step in `.github/workflows/conventions.yml` to fix configuration for the `IamPekka058/branchMatchRegex` GitHub Action.