### PR TITLE
🔧 Config renovate to automerge patches

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -4,10 +4,11 @@
     "major": {
         "automerge": false
     },
-    "labels": ["📌 Dependencies"],
-    "commitMessagePrefix": "⬆️",
-    "commitMessageAction": "Upgrade",
     "packageRules": [
+        {
+            "matchUpdateTypes": ["patch"],
+            "automerge": true
+        },
         {
             "matchUpdateTypes": ["pin"],
             "commitMessagePrefix": "📌",
@@ -19,6 +20,9 @@
             "commitMessageAction": "Downgrade"
         }
     ],
+    "commitMessagePrefix": "⬆️",
+    "commitMessageAction": "Upgrade",
+    "labels": ["📌 Dependencies"],
     "dependencyDashboardTitle": "📌 Dependency Dashboard",
     "dependencyDashboardLabels": ["📌 Dependencies"]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve how dependency updates are managed and labeled. The changes primarily reorganize where global settings for commit messages and labels are defined, and add a new rule to automatically merge patch updates.

Dependency update automation:

* Added a new package rule to automatically merge patch-level dependency updates.

Configuration organization:

* Moved global settings for `commitMessagePrefix`, `commitMessageAction`, and `labels` from inside a package rule to the top-level configuration, ensuring these settings apply consistently to all updates. [[1]](diffhunk://#diff-15f699efb1e602fd93a93bb239702716a1eefd61deb233d55440e8edebf7080aL7-R11) [[2]](diffhunk://#diff-15f699efb1e602fd93a93bb239702716a1eefd61deb233d55440e8edebf7080aR23-R25)