### PR TITLE
👷 Auto add issue to issue tracker

### DIFF
--- a/.github/workflows/action-add-issue-tracker.yml
+++ b/.github/workflows/action-add-issue-tracker.yml
@@ -1,0 +1,14 @@
+name: Add to issue tracker
+
+on:
+    workflow_call:
+
+jobs:
+    add-to-project:
+        name: Add issue to project
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/add-to-project@v1.0.2
+              with:
+                  project-url: https://github.com/orgs/RubberDuckCrew/projects/1
+                  github-token: ${{ secrets.PAT_ADD_PROJECTS }}

--- a/.github/workflows/add-issue-tracker.yml
+++ b/.github/workflows/add-issue-tracker.yml
@@ -1,0 +1,11 @@
+name: Add to issue tracker
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    run:
+        # uses: RubberDuckCrew/.github/.github/workflows/action-add-issue-tracker.yml.yml@main
+        uses: ./.github/workflows/action-add-issue-tracker.yml
+        secrets: inherit


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows to automate adding newly opened issues to the organization's issue tracker project. The main changes involve setting up reusable workflow files and integrating them for automatic issue tracking.

**Workflow automation for issue tracking:**

* Added a reusable workflow in `.github/workflows/action-add-issue-tracker.yml` that uses the `actions/add-to-project` action to add issues to the organization's project board when triggered.
* Created `.github/workflows/add-issue-tracker.yml` to trigger the reusable workflow whenever a new issue is opened, ensuring issues are automatically added to the project.