### PR TITLE
🔧 Renovate pin actions to digests

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -7,6 +7,10 @@
     "rangeStrategy": "pin",
     "packageRules": [
         {
+            "matchDepTypes": ["action"],
+            "pinDigests": true
+        },
+        {
             "matchUpdateTypes": ["patch"],
             "automerge": true
         },


### PR DESCRIPTION
This pull request introduces a configuration update to the Renovate setup, specifically targeting dependencies of type "action". The main change ensures that digests are pinned for these dependencies, which helps maintain consistency and security in automated dependency updates.

Renovate configuration improvements:

* Added a rule to pin digests for dependencies with `depType` set to "action" in `configs/renovate/renovate-rubberduckcrew.json`.

https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to pin digests for action-related dependencies. This improves reliability and integrity of automated updates, ensuring builds are repeatable and less prone to supply-chain drift. No functional changes to the app; this enhances stability of CI/CD processes and reduces risk during dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->