### PR TITLE
🔧 Set pin digest commit message

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -15,7 +15,7 @@
             "automerge": true
         },
         {
-            "matchUpdateTypes": ["pin"],
+            "matchUpdateTypes": ["pin", "pinDigest", "digest"],
             "commitMessagePrefix": "📌",
             "commitMessageAction": "Pin"
         },


### PR DESCRIPTION
This pull request makes a small update to the Renovate configuration for the Rubberduck Crew. The change expands the types of dependency updates that trigger a "Pin" commit message.

* The `matchUpdateTypes` array in `configs/renovate/renovate-rubberduckcrew.json` now includes `"pinDigest"` and `"digest"` in addition to `"pin"`, so Renovate will use the "Pin" commit message for these update types as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded automated dependency update rules to include digest-related pins alongside standard pin updates, improving coverage and consistency of maintenance PRs.
  - Commit message formatting remains unchanged, preserving existing prefixes and actions for easier tracking.
  - No impact on application behavior; this only affects the scope and reliability of automated dependency update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->