### PR TITLE
👷 Add concurrency to docs action

### DIFF
--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -8,6 +8,10 @@ on:
                 required: true
                 description: "Cloudflare Pages project name"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         name: Build docs


### PR DESCRIPTION
This pull request introduces a workflow improvement to the `.github/workflows/action-docs.yml` file by adding concurrency controls to the GitHub Actions workflow.

Workflow management:

* Added a `concurrency` group to ensure that only one instance of the workflow runs per branch or PR, and that in-progress runs are cancelled when a new run is triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow to prevent overlapping runs by canceling in-progress executions when newer commits are pushed.
  * Reduces redundant builds and speeds up feedback during active development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->