### PR TITLE
👷 Skip jobs if secrets not available to prevent failing in forks

### DIFF
--- a/.github/workflows/action-add-project.yml
+++ b/.github/workflows/action-add-project.yml
@@ -13,13 +13,22 @@ jobs:
         name: Add issue to project
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
+            - name: Check if secrets are available
+              id: check-secrets
+              run: |
+                  echo "secrets_available=${{ vars.RUBBERDUCKCREW_BOT_APP_ID && secrets.RUBBERDUCKCREW_BOT_APP_PRIVATE_KEY && 'true' || '' }}" >> "$GITHUB_OUTPUT"
+
+            - name: Create GitHub App token
+              uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
+              if: ${{ steps.check-secrets.outputs.secrets_available }}
               id: app-token
               with:
                   app-id: ${{ vars.RUBBERDUCKCREW_BOT_APP_ID }}
                   private-key: ${{ secrets.RUBBERDUCKCREW_BOT_APP_PRIVATE_KEY }}
 
-            - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+            - name: Add to project
+              uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+              if: ${{ steps.app-token.outputs.token }}
               with:
                   project-url: ${{ inputs.project-url }}
                   github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -40,6 +40,7 @@ jobs:
               with:
                   node-version: 22.19.0
                   cache: npm
+                  cache-dependency-path: ${{ inputs.docs-path }}/package-lock.json
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Check if secrets are available
               id: check-secrets
               run: |
-                  echo "secrets_available='${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}'" >> $GITHUB_OUTPUT
+                  echo "secrets_available=${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}" >> "$GITHUB_OUTPUT"
 
     deploy:
         name: Deploy docs

--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -7,6 +7,11 @@ on:
                 type: string
                 required: true
                 description: "Cloudflare Pages project name"
+            docs-path:
+                type: string
+                required: false
+                default: "docs"
+                description: "Path to the docs directory"
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +24,10 @@ jobs:
 
         defaults:
             run:
-                working-directory: docs
+                working-directory: ${{ inputs.docs-path }}
+
+        outputs:
+            secrets_available: ${{ steps.check-secrets.outputs.secrets_available }}
 
         steps:
             - name: Checkout
@@ -32,7 +40,6 @@ jobs:
               with:
                   node-version: 22.19.0
                   cache: npm
-                  cache-dependency-path: docs/package-lock.json
 
             - name: Install dependencies
               run: npm ci
@@ -44,12 +51,18 @@ jobs:
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: docs-dist
-                  path: docs/.vitepress/dist
+                  path: ${{ inputs.docs-path }}/.vitepress/dist
+
+            - name: Check if secrets are available
+              id: check-secrets
+              run: |
+                  $SECRETS_AVAILABLE="${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}"
+                  echo "secrets_available=$SECRETS_AVAILABLE" >> $GITHUB_OUTPUT
 
     deploy:
         name: Deploy docs
         needs: build
-        if: ${{ ( github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, '🚀 Request Deploy') ) && !github.event.pull_request.head.repo.fork}}
+        if: ${{ ( github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, '🚀 Request Deploy') ) && needs.build.outputs.secrets_available }}
         runs-on: ubuntu-latest
 
         permissions:

--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -57,8 +57,7 @@ jobs:
             - name: Check if secrets are available
               id: check-secrets
               run: |
-                  $SECRETS_AVAILABLE="${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}"
-                  echo "secrets_available=$SECRETS_AVAILABLE" >> $GITHUB_OUTPUT
+                  echo "secrets_available=${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}" >> $GITHUB_OUTPUT
 
     deploy:
         name: Deploy docs

--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Check if secrets are available
               id: check-secrets
               run: |
-                  echo "secrets_available=${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}" >> $GITHUB_OUTPUT
+                  echo "secrets_available='${{ secrets.CLOUDFLARE_API_TOKEN && secrets.CLOUDFLARE_ACCOUNT_ID && 'true' || '' }}'" >> $GITHUB_OUTPUT
 
     deploy:
         name: Deploy docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,20 @@ name: Build and deploy docs
 on:
     push:
         branches: [main]
-        paths: [docs/**, .github/workflows/docs.yml]
+        paths:
+            [
+                docs/**,
+                .github/workflows/docs.yml,
+                .github/workflows/action-docs.yml,
+            ]
     pull_request:
         types: [opened, labeled, synchronize]
-        paths: [docs/**, .github/workflows/docs.yml]
+        paths:
+            [
+                docs/**,
+                .github/workflows/docs.yml,
+                .github/workflows/action-docs.yml,
+            ]
 
 jobs:
     run:


### PR DESCRIPTION
This pull request introduces improvements to the documentation build and deploy GitHub Actions workflow, making it more flexible and robust. The main changes add support for customizing the docs directory path, improve handling of secrets, and ensure the workflow only attempts deployment when necessary secrets are present.

**Workflow flexibility and configuration:**

* Added a new optional `docs-path` input to the workflow, allowing users to specify a custom path to the documentation directory instead of being hardcoded to `docs` (`.github/workflows/action-docs.yml`).
* Updated all workflow steps to use the `${{ inputs.docs-path }}` variable for the working directory and artifact paths, supporting the new configurable docs path (`.github/workflows/action-docs.yml`). [[1]](diffhunk://#diff-27d492cbd5811899afa83d15355411409bc26ed13b0c1b846fd032cee2f38fcdL22-R30) [[2]](diffhunk://#diff-27d492cbd5811899afa83d15355411409bc26ed13b0c1b846fd032cee2f38fcdL47-R65)

**Secrets handling and deployment safety:**

* Added a step to check if required secrets (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`) are available, and exposed this as a workflow output (`.github/workflows/action-docs.yml`).
* Updated the deploy job to only run if the required secrets are available, preventing failed deployments due to missing secrets (`.github/workflows/action-docs.yml`).

**Other improvements:**

* Removed the hardcoded `cache-dependency-path` for npm caching, which is now implicitly handled by the dynamic docs path (`.github/workflows/action-docs.yml`).