### PR TITLE
🔧 Set renovate minimum release age to 3 days

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -46,5 +46,6 @@
     "labels": ["📌 Dependencies", "🔒️ Security"],
     "commitMessagePrefix": "🔒️",
     "commitMessageAction": "Security Fix"
-  }
+  },
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
This pull request introduces a configuration update to the Renovate bot settings, specifically adding a minimum release age for dependency updates. This ensures that only packages released at least three days ago will be considered for updates, helping to avoid issues with unstable or quickly-patched releases.

Dependency update policy:

* Added the `"minimumReleaseAge": "3 days"` setting to the Renovate configuration file (`renovate-rubberduckcrew.json`) to delay dependency updates until a release has been available for at least three days.