### PR TITLE
:wrench: Move minimumReleaseAge to specific Renovate rule

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -19,6 +19,9 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true,
+    },
+    {
+      "matchUpdateTypes": ["patch", "minor", "major"],
       "minimumReleaseAge": "3 days"
     },
     {
@@ -46,6 +49,5 @@
     "labels": ["📌 Dependencies", "🔒️ Security"],
     "commitMessagePrefix": "🔒️",
     "commitMessageAction": "Security Fix"
-  },
-  "minimumReleaseAge": "3 days"
+  }
 }

--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -18,7 +18,7 @@
     },
     {
       "matchUpdateTypes": ["patch"],
-      "automerge": true,
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["patch", "minor", "major"],


### PR DESCRIPTION
This pull request updates the `renovate-rubberduckcrew.json` configuration to improve how dependencies are managed and automerged. The most important changes are focused on automerge rules and the handling of release age for updates.

Dependency update and automerge configuration:

* Added a new rule to delay automerging of all updates (patch, minor, and major) until they are at least 3 days old, ensuring more time for review before merging.
* Removed the global `minimumReleaseAge` setting and moved it into a specific update rule for better control and clarity.