### PR TITLE
👷 Rename github app-id to client-id

### DIFF
--- a/.github/workflows/action-sync-webhook.yml
+++ b/.github/workflows/action-sync-webhook.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.check-secrets.outputs.secrets_available }}
         id: app-token
         with:
-          app-id: ${{ inputs.bot-app-id }}
+          client-id: ${{ inputs.bot-app-id }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Webhook Sync


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/action-sync-webhook.yml` workflow file. The change updates the input parameter name from `app-id` to `client-id` when passing the bot app ID to a step, likely to align with updated requirements or conventions.

- Updated the parameter from `app-id` to `client-id` for the bot app ID input in the workflow step.