### PR TITLE
🔧 Disable min release age for RubberDuckCrew dependencies

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -25,6 +25,10 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "matchSourceUrls": ["https://github.com/RubberDuckCrew/**"],
+      "minimumReleaseAge": null
+    },
+    {
       "matchUpdateTypes": ["pin", "pinDigest", "digest"],
       "commitMessagePrefix": "📌",
       "commitMessageAction": "Pin"


### PR DESCRIPTION
This pull request updates the Renovate configuration to allow immediate updates for packages sourced from the RubberDuckCrew GitHub organization, overriding the default release age restriction.

Dependency update policy changes:

* Added a new rule in `renovate-rubberduckcrew.json` to set `minimumReleaseAge` to `null` for dependencies with source URLs matching `https://github.com/RubberDuckCrew/**`, allowing immediate updates for these packages.