### PR TITLE
👷 Replace label enforcing with auto labeler

### DIFF
--- a/.github/workflows/action-conventions.yml
+++ b/.github/workflows/action-conventions.yml
@@ -2,6 +2,11 @@ name: Enforce conventions
 
 on:
   workflow_call:
+    inputs:
+      additional-labeler-config:
+        description: "Additional labeler config file in the repo"
+        required: false
+        type: string
 
 jobs:
   enforce-labels:
@@ -12,16 +17,27 @@ jobs:
       issues: write
       pull-requests: write
 
+  labeler:
+    name: Auto-assign pull request labels
+    runs-on: ubuntu-latest
     steps:
-      - name: Enforce pull request labels
-        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
+      - name: Checkout additional config
+        if: ${{ inputs.additional-labeler-config }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          mode: minimum
-          count: 1
-          labels: "^(?!(⚗️ Request Build$|💬 Discussion$|❓ Question$|❌ Wontfix$|🔄 Duplicate$|🚧 Work in Progress$)).+" # Exclude meta labels (do not describe PR content)
-          use_regex: true
-          add_comment: true
-          message: "🏷️ Please assign at least one label to this pull request before requesting a review. See our [contributing conventions](https://rubberduckcrew.pages.dev/contributing/conventions) for details."
+          sparse-checkout: ${{ inputs.additional-labeler-config }}
+
+      - name: Get Central Config
+        run: curl -s https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/labeler.yml > labeler-config.yml
+
+      - name: Merge Configs
+        if: ${{ inputs.additional-labeler-config }}
+        run: |
+          cat ${{ inputs.additional-labeler-config }} >> labeler-config.yml
+
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: "labeler-config.yml"
 
   enforce-branch-names:
     name: Enforce pull request branch names

--- a/.github/workflows/action-conventions.yml
+++ b/.github/workflows/action-conventions.yml
@@ -9,17 +9,12 @@ on:
         type: string
 
 jobs:
-  enforce-labels:
-    name: Enforce pull request labels
-    runs-on: ubuntu-latest
-
-    permissions:
-      issues: write
-      pull-requests: write
-
   labeler:
     name: Auto-assign pull request labels
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - name: Checkout additional config
         if: ${{ inputs.additional-labeler-config }}

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -2,7 +2,7 @@ name: Enforce conventions
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened]
 
 jobs:
   run:

--- a/configs/conventions/labeler.yml
+++ b/configs/conventions/labeler.yml
@@ -1,0 +1,20 @@
+"✨ Enhancement":
+  - head-branch: ["^feat/"]
+"🐛 Bug":
+  - head-branch: ["^fix/"]
+"📝 Documentation":
+  - head-branch: ["^docs/"]
+"🧪 Testing":
+  - head-branch: ["^test/"]
+"♻️ Refactor":
+  - head-branch: ["^refactor/"]
+"💄 UI/UX":
+  - head-branch: ["^ui/"]
+"👷 CI/CD":
+  - head-branch: ["^ci/"]
+"🔧 Configuration":
+  - head-branch: ["^config/"]
+"🔒️ Security":
+  - head-branch: ["^security/"]
+"🛠️ Maintenance":
+  - head-branch: ["^chore/"]


### PR DESCRIPTION
This pull request updates the repository's pull request labeling workflow to make label assignment more automated and configurable. It introduces a new central labeler configuration, allows for additional repo-specific config, and streamlines how and when labeling is triggered. The changes also add a new labeler config file that maps branch name patterns to specific labels.

**Workflow automation and configuration improvements:**

* Added a new `labeler` job to `.github/workflows/action-conventions.yml` that automatically assigns pull request labels based on branch name patterns, using a central config file and optionally merging in repo-specific config if provided.
* Introduced a new input (`additional-labeler-config`) to the workflow, allowing repositories to specify extra labeler configuration files.
* Updated the workflow to fetch a central labeler config from the RubberDuckCrew `.github` repo and merge it with any additional config from the consuming repo.

**Labeling rules and triggers:**

* Added a new `configs/conventions/labeler.yml` file that defines label-to-branch-pattern mappings for common PR types (e.g., Enhancement, Bug, Documentation, etc.).
* Changed `.github/workflows/conventions.yml` to only run on the `opened` event for pull requests, instead of also triggering on label changes or synchronizations.