### PR TITLE
🔧 Pin docker images with renovate

### DIFF
--- a/configs/renovate/renovate-rubberduckcrew.json
+++ b/configs/renovate/renovate-rubberduckcrew.json
@@ -37,6 +37,14 @@
       "matchUpdateTypes": ["rollback"],
       "commitMessagePrefix": "⬇️",
       "commitMessageAction": "Downgrade"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "pinDigests": true
+    },
+    {
+      "matchManagers": ["argocd", "devcontainer", "helmv3", "pyenv"],
+      "pinDigests": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve how dependency digests are pinned for certain package managers and datasources.

Dependency digest pinning:

* Added a rule to pin digests for Docker dependencies by setting `pinDigests` to `true` when `matchDatasources` is `docker`.
* Added a rule to not pin digests for dependencies managed by `argocd`, `devcontainer`, `helmv3`, and `pyenv` by setting `pinDigests` to `false` for these managers.