### PR TITLE
:sparkles: Add user-story-template to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.yaml
+++ b/.github/ISSUE_TEMPLATE/user-story.yaml
@@ -1,0 +1,73 @@
+name: 📖 User Story
+description: Describe a user story for this project
+type: feature
+labels: "📖 User Story"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for creating this user story!
+        Please check open and closed issues beforehand to avoid duplicates.
+  - type: textarea
+    id: user-story
+    attributes:
+      label: 📝 User Story
+      description: Describe the user story in the format "As a... I want to... So that..."
+      placeholder: |
+        As a [user role]
+        I want to [perform an action]
+        So that [I can achieve a benefit/value]
+      validations:
+        required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: ✅ Acceptance Criteria
+      description: Define measurable criteria that must be met for this story to be considered "done".
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: 🎯 Definition of Done (Optional)
+      description: Specific requirements like tests, documentation, code review, etc.
+      placeholder: |
+        - [ ] Unit tests written
+        - [ ] Code review passed
+        - [ ] Documentation updated
+        - [ ] Manually tested
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 🎨 Additional Context (Optional)
+      description: Add wireframes, screenshots, links, or any other helpful information.
+      placeholder: e.g. "See Figma design: [link]"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: check-duplicate
+    attributes:
+      label: No duplicate issue
+      description: Confirm that you have searched for open and closed issues with the same user story beforehand.
+      options:
+        - label: I confirm that this issue is not a duplicate
+          required: true
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://rubberduckcrew.pages.dev/contributing/code-of-conduct).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yaml
+++ b/.github/ISSUE_TEMPLATE/user-story.yaml
@@ -50,7 +50,7 @@ body:
     attributes:
       label: 🎨 Additional Context (Optional)
       description: Add wireframes, screenshots, links, or any other helpful information.
-      placeholder: e.g. "See Figma design: [link]"
+      placeholder: 'e.g. "See Figma design: [link]"'
     validations:
       required: false
 


### PR DESCRIPTION
This pull request introduces a new issue template for user stories to standardize and improve the process of submitting feature requests. The template guides users to provide clear user stories, acceptance criteria, and relevant context, while ensuring issues are not duplicates and that contributors agree to the project's Code of Conduct.

**New Issue Template for User Stories:**

* Added `.github/ISSUE_TEMPLATE/user-story.yaml` to provide a structured form for submitting user stories, including sections for the user story description, acceptance criteria, definition of done, additional context, and required confirmations for duplicate checking and Code of Conduct agreement.